### PR TITLE
Added "Copy JPEGs only" option to skip RAW files...

### DIFF
--- a/SnowyImageCopy/Models/FileExtension.cs
+++ b/SnowyImageCopy/Models/FileExtension.cs
@@ -22,7 +22,7 @@ namespace SnowyImageCopy.Models
 		kdc, // Kodac raw (Microsoft Camera Codec Pack supports some models)
 		rwl, // Leica raw
 		nef, // Nikon raw (Microsoft Camera Codec Pack supports some models)
-		orf, // Olympus raw (Microsoft Camera Codec Pack supports some models)
+        orf, // Olympus raw (Microsoft Camera Codec Pack supports some models)
 		rw2, // Panasonic raw (Microsoft Camera Codec Pack supports some models)
 		pef, // Pentax raw (Microsoft Camera Codec Pack supports some models)
 		srw, // Samsung raw (Microsoft Camera Codec Pack supports some models)

--- a/SnowyImageCopy/Models/FileItem.cs
+++ b/SnowyImageCopy/Models/FileItem.cs
@@ -39,7 +39,7 @@ namespace SnowyImageCopy.Models
 
 		public bool IsImported { get; private set; }
 
-		public string FilePath
+        public string FilePath
 		{
 			get { return _filePath ?? (_filePath = String.Format("{0}/{1}", Directory, FileName)); }
 		}
@@ -56,7 +56,13 @@ namespace SnowyImageCopy.Models
 			get { return (FileExtension != FileExtension.other); }
 		}
 
-		private static readonly string[] _flashAirSystemFolders =
+        // NYGG
+        public bool IsJpeg
+        {
+            get { return FileExtension == FileExtension.jpg || FileExtension == FileExtension.jpeg; }
+        }
+
+        private static readonly string[] _flashAirSystemFolders =
 		{
 			"GUPIXINF",
 			"SD_WLAN",

--- a/SnowyImageCopy/Models/FileManager.cs
+++ b/SnowyImageCopy/Models/FileManager.cs
@@ -92,7 +92,7 @@ namespace SnowyImageCopy.Models
 
 				if (!itemList[i].IsDirectory)
 				{
-					if (!itemList[i].IsImageFile)
+					if (!itemList[i].IsImageFile || (Settings.Current.CopyJpegsOnly && !itemList[i].IsJpeg))
 					{
 						itemList.Remove(itemList[i]);
 					}

--- a/SnowyImageCopy/Models/IFileItem.cs
+++ b/SnowyImageCopy/Models/IFileItem.cs
@@ -24,9 +24,11 @@ namespace SnowyImageCopy.Models
 
 		bool IsImported { get; }
 
-		string FilePath { get; }
+        string FilePath { get; }
 		string Signature { get; }
 		bool IsImageFile { get; }
-		bool IsFlashAirSystemFolder { get; }
+        // NYGG
+        bool IsJpeg { get; }
+        bool IsFlashAirSystemFolder { get; }
 	}
 }

--- a/SnowyImageCopy/Models/Settings.cs
+++ b/SnowyImageCopy/Models/Settings.cs
@@ -364,11 +364,25 @@ namespace SnowyImageCopy.Models
 		}
 		private bool _enablesChooseDeleteOnCopy;
 
-		#endregion
+        public bool CopyJpegsOnly
+        {
+            get { return _copyJpegsOnly; }
+            set
+            {
+                if (_copyJpegsOnly == value)
+                    return;
 
-		#region Culture
+                _copyJpegsOnly = value;
+                RaisePropertyChanged();
+            }
+        }
+        private bool _copyJpegsOnly = true; // Default
 
-		public string CultureName
+        #endregion
+
+        #region Culture
+
+        public string CultureName
 		{
 			get { return _cultureName; }
 			set

--- a/SnowyImageCopy/Properties/Resources.Designer.cs
+++ b/SnowyImageCopy/Properties/Resources.Designer.cs
@@ -422,6 +422,15 @@ namespace SnowyImageCopy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy JPEGs only.
+        /// </summary>
+        public static string Options_CopyJpegsOnly {
+            get {
+                return ResourceManager.GetString("Options_CopyJpegsOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create folder for each date.
         /// </summary>
         public static string Options_CreateDatedFolder {

--- a/SnowyImageCopy/Properties/Resources.ja-JP.resx
+++ b/SnowyImageCopy/Properties/Resources.ja-JP.resx
@@ -255,6 +255,9 @@
   <data name="Options_ExtensionLowercase" xml:space="preserve">
     <value>ファイル拡張子を小文字にする</value>
   </data>
+  <data name="Options_CopyJpegsOnly" xml:space="preserve">
+    <value>コピーJPEGファイルだけ</value>
+  </data>
   <data name="Options_File" xml:space="preserve">
     <value>ファイル</value>
   </data>

--- a/SnowyImageCopy/Properties/Resources.resx
+++ b/SnowyImageCopy/Properties/Resources.resx
@@ -259,6 +259,9 @@
   <data name="Options_ExtensionLowercase" xml:space="preserve">
     <value>Make file extension lowercase</value>
   </data>
+  <data name="Options_CopyJpegsOnly" xml:space="preserve">
+    <value>Copy JPEGs only</value>
+  </data>
   <data name="Options_File" xml:space="preserve">
     <value>File</value>
   </data>

--- a/SnowyImageCopy/Views/Options.xaml
+++ b/SnowyImageCopy/Views/Options.xaml
@@ -181,7 +181,20 @@
 							IsChecked="{Binding SettingsCurrent.MakesFileExtensionLowercase, Mode=TwoWay}"/>
 					</GroupBox>
 
-					<GroupBox Template="{StaticResource ItemDetailedTemplate}"
+                    <GroupBox Template="{StaticResource ItemDetailedTemplate}"
+							  Header="{Binding Resources.Options_CopyJpegsOnly, Source={x:Static models:ResourceService.Current}}">
+                        <controls:SlidingToggleButton
+							Width="60" Height="24"
+							TextChecked="ON"
+							TextUnchecked="OFF"
+							ForegroundChecked="{StaticResource Sliding.Checked.Foreground}"
+							ForegroundUnchecked="{StaticResource Sliding.Unchecked.Foreground}"
+							BackgroundChecked="{StaticResource Sliding.Checked.Background}"
+							BackgroundUnchecked="{StaticResource Sliding.Unchecked.Background}"
+							IsChecked="{Binding SettingsCurrent.CopyJpegsOnly, Mode=TwoWay}"/>
+                    </GroupBox>
+
+                    <GroupBox Template="{StaticResource ItemDetailedTemplate}"
 							  Header="{Binding Resources.Options_Recycle, Source={x:Static models:ResourceService.Current}}">
 						<controls:SlidingToggleButton
 							x:Name="RecycleButton"


### PR DESCRIPTION
… where speed is more important than quality.

I'd like to use Snowy to pick up pictures for printing 4"x6" in a "photo booth".
Medium JPEGs transfer in about 5 seconds.  Transferring ORF files adds another 20 seconds which makes the event less spontaneous.

Sorry if the Japanese translation isn't quite right.